### PR TITLE
build: adopt TypeScript 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     groups:
       npm:
         patterns: ["*"]
+    # @types/node tracks the minimum supported Node (engines), not the latest
+    # release, so its major moves only when the engines floor is raised.
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@biomejs/biome": "^2.0.0",
         "@types/node": "^22.19.21",
         "fast-check": "^4.0.0",
-        "typescript": "^5.5.0"
+        "typescript": "^6.0.0"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -232,9 +232,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@biomejs/biome": "^2.0.0",
     "@types/node": "^22.19.21",
     "fast-check": "^4.0.0",
-    "typescript": "^5.5.0"
+    "typescript": "^6.0.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noEmit": true,
     "allowImportingTsExtensions": true,
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["node"]
   },
   "include": ["src", "test"]
 }


### PR DESCRIPTION
Adopts TypeScript 6 (the current major) and fixes the typecheck break it causes, superseding the grouped Dependabot bump in #29.

## What and why

The rewrite pinned `typescript` to `^5.5.0`, which locked out the 6.x major that was already current. Under TS 6 the test typecheck no longer auto-includes `@types/node`, so `node:test` / `node:assert` stopped resolving. The fix is one line: `"types": ["node"]` in `tsconfig.test.json`. The `dist` build is unaffected, since `src` uses no Node built-ins. Verified green on Node 22/24/26: lint, typecheck, build, tests, 100% coverage.

`@types/node` stays at `^22` on purpose. Its major should track the minimum supported Node (the 22.12 `engines` floor), not the newest release, so the code is not typechecked against APIs that are absent at runtime. Dependabot now ignores `@types/node` major bumps for that reason, and it moves only when the floor is raised. TypeScript is not gated, so 6.x and beyond keep flowing as normal.

## On #29

This supersedes #29. Closing keywords only auto-close issues, not PRs, so after merging this, close #29 manually. That is safe: closing a grouped Dependabot PR does not create ignore conditions, so future TypeScript updates are unaffected.
