### PR TITLE
ci: add release-please, npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - uses: googleapis/release-please-action@v5
+        id: release
+        with:
+          release-type: node
+          include-component-in-tag: false
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "format-duration",
-  "version": "4.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "format-duration",
-      "version": "4.0.0",
+      "version": "3.0.2",
       "license": "ISC",
       "devDependencies": {
         "@biomejs/biome": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "format-duration",
   "description": "Convert a number in milliseconds to a standard duration string.",
   "version": "3.0.2",
-  "type": "module",
   "author": "Nate Goldman <ungoldman@gmail.com> (https://ungoldman.com/)",
   "bugs": {
     "url": "https://github.com/ungoldman/format-duration/issues"
@@ -45,16 +44,17 @@
     "url": "git+https://github.com/ungoldman/format-duration.git"
   },
   "scripts": {
-    "prebuild": "rm -rf dist",
     "build": "tsc",
+    "coverage": "node --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 test/*.test.ts",
     "format": "biome format --write .",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
+    "prebuild": "rm -rf dist",
     "prepublishOnly": "npm run build",
     "test": "npm run lint && npm run typecheck && npm run build && node --test test/*.test.ts",
-    "typecheck": "tsc -p tsconfig.test.json",
-    "coverage": "node --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 test/*.test.ts"
+    "typecheck": "tsc -p tsconfig.test.json"
   },
   "sideEffects": false,
+  "type": "module",
   "types": "./dist/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "format-duration",
   "description": "Convert a number in milliseconds to a standard duration string.",
-  "version": "4.0.0",
+  "version": "3.0.2",
   "type": "module",
   "author": "Nate Goldman <ungoldman@gmail.com> (https://ungoldman.com/)",
   "bugs": {


### PR DESCRIPTION
Adds planned release automation: `release-please` for versioning and changelog, and tokenless npm publish via OIDC trusted publishing.

## How it works

On every push to `main`, release-please reads the conventional commits since the last release and maintains a release PR that bumps `package.json` and prepends to `CHANGELOG.md`. Merging that PR tags the version and creates a GitHub Release, which triggers the publish job: `npm ci`, build, then `npm publish` authenticated by a short-lived OIDC token. Provenance attestations are generated automatically.

Files added:
- `release-please-config.json`: `release-type: node`, with `include-component-in-tag: false` so tags stay `vX.Y.Z` (matching `v3.0.2`).
- `.release-please-manifest.json`: seeded to `3.0.2`, the last published version, so release-please diffs from the `v3.0.2` tag.
- `.github/workflows/release.yml`: the release-please job plus the OIDC publish job.

## Setup needed before this can publish (only you can do these)

1. **npmjs.com trusted publisher**: on the format-duration package, Settings, Trusted Publishing, add a GitHub Actions publisher with org `ungoldman`, repo `format-duration`, workflow `release.yml`, and select `npm publish` as the allowed action.
2. **GitHub repo setting**: Settings, Actions, General, Workflow permissions, enable "Allow GitHub Actions to create and approve pull requests" so release-please can open the release PR with the default token. Best to do this before merging, since the first run happens on merge.

## What happens on merge

release-please sees the `refactor!` breaking commit since `v3.0.2` and opens a release PR for 4.0.0 with a generated changelog (the breaking-changes section comes from the commit footer, and the ci/chore/docs commits stay hidden). Review and merge that PR to cut and publish 4.0.0. If the trusted publisher is not configured yet, only the publish job fails, so configure it and re-run that job.

## Note on CI

This workflow triggers on push to `main`, not on PRs, so it does not run on this PR. The `tests` workflow still runs here. release-please activates once this is merged.
