### PR TITLE
build: scope biome to source and simplify its scripts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-  "files": { "includes": ["src/**", "test/**", "*.json"] },
+  "files": { "includes": ["src/**", "test/**"] },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,8 @@
   "scripts": {
     "build": "tsc",
     "coverage": "node --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 test/*.test.ts",
-    "format": "biome format --write .",
+    "format": "biome check --write .",
     "lint": "biome check .",
-    "lint:fix": "biome check --write .",
     "prebuild": "rm -rf dist",
     "prepublishOnly": "npm run build",
     "test": "npm run lint && npm run typecheck && npm run build && node --test test/*.test.ts",


### PR DESCRIPTION
Two small tooling cleanups carried back from applying the same setup to hyperaxe.

## Changes
- Drop `*.json` from Biome's `includes` so it stops formatting `package.json` (fixpack owns that) and the config JSON. `package-lock.json` was already auto-ignored.
- Collapse the three Biome scripts to two: `format` now runs `biome check --write` (fix and tidy in one), and the redundant `lint:fix` is removed, leaving `lint` (verify) and `format` (fix).

## Verification
`npm test` (lint, typecheck, build, 10 tests) passes locally.